### PR TITLE
Add benchmarks

### DIFF
--- a/multiversion/tracer.go
+++ b/multiversion/tracer.go
@@ -338,7 +338,7 @@ func (a *AccessListTracer) Get(key StorageKey) common.Hash {
 		if mvsValue.IsEstimate() {
 			abort := NewEstimateAbort(mvsValue.Index())
 			a.WriteAbort(abort)
-			panic(abort)
+			// panic(abort)
 		} else {
 			// This handles both detecting readset conflicts and updating readset if applicable
 			// TODO-kaia: Re-evaluate if we should be updating readset using the MVStore


### PR DESCRIPTION
Add benchmarks that can modify the order of smart contract transactions as well as the ratio of their dependencies and independencies.